### PR TITLE
Expose Edge data structure

### DIFF
--- a/src/com/nodename/Delaunay/Edge.as
+++ b/src/com/nodename/Delaunay/Edge.as
@@ -17,7 +17,7 @@ package com.nodename.Delaunay
 	 * @author ashaw
 	 * 
 	 */
-	internal final class Edge
+	public final class Edge
 	{
 		private static var _pool:Vector.<Edge> = new Vector.<Edge>();
 
@@ -123,7 +123,14 @@ package com.nodename.Delaunay
 			// draw a line connecting the input Sites for which the edge is a bisector:
 			return new LineSegment(leftSite.coord, rightSite.coord);
 		}
-		
+
+                public function voronoiEdge():LineSegment
+                {
+                  if (!visible) return new LineSegment(null, null);
+                  return new LineSegment(_clippedVertices[LR.LEFT],
+                                         _clippedVertices[LR.RIGHT]);
+                }
+
 		private static var _nedges:int = 0;
 		
 		internal static const DELETED:Edge = new Edge(PrivateConstructorEnforcer);

--- a/src/com/nodename/Delaunay/Voronoi.as
+++ b/src/com/nodename/Delaunay/Voronoi.as
@@ -98,7 +98,12 @@ package com.nodename.Delaunay
 			_sites.push(site);
 			_sitesIndexedByLocation[p] = site;
 		}
-		
+
+                public function edges():Vector.<Edge>
+                {
+                	return _edges;
+                }
+          
 		public function region(p:Point):Vector.<Point>
 		{
 			var site:Site = _sitesIndexedByLocation[p];
@@ -108,7 +113,8 @@ package com.nodename.Delaunay
 			}
 			return site.region(_plotBounds);
 		}
-		
+
+          // TODO: bug: if you call this before you call region(), something goes wrong :(
 		public function neighborSitesForSite(coord:Point):Vector.<Point>
 		{
 			var points:Vector.<Point> = new Vector.<Point>();


### PR DESCRIPTION
Made Edge data structure public. It appears to be the only convenient way to figure out which polygon edges link which polygons. Added a function to get the dual edge (the dual of the Voronoi polygon edge is a Delaunay triangle edge).
